### PR TITLE
Feature/export markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   },
   "dependencies": {
     "deepmerge": "^4.2.2",
+    "file-saver": "^2.0.5",
     "firebase": "^9.9.0",
     "force-graph": "^1.35.1",
     "ink-mde": "^0.14.1",
+    "jszip": "^3.10.1",
     "localforage": "^1.10.0",
     "mime-types": "^2.1.35",
     "moment": "^2.29.4",
@@ -32,8 +34,10 @@
   },
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.0",
+    "@types/file-saver": "^2.0.5",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^18.0.6",
+    "@types/remarkable": "^2.0.3",
     "@vitejs/plugin-vue": "2",
     "autoprefixer": "^10.3.6",
     "deepmerge-ts": "^4.2.1",

--- a/pages/docs/export.vue
+++ b/pages/docs/export.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="container mx-auto p-4 flex">
-    <pre contenteditable ref="editable" class="editable monospace h-auto w-full text-current bg-transparent outline-none">{{value}}</pre>
+    <button class="button button-size-medium button-color-gray" v-on:click="exportFiles">Export documents</button>
   </div>
 </template>
 
 <script>
+import { saveAs } from 'file-saver';
+import JSZip from 'jszip'
+
 export default {
   computed: {
     value() {
@@ -12,12 +15,18 @@ export default {
     },
   },
   methods: {
-    focus() {
-      this.$refs.editable.focus()
-    },
-  },
-  mounted() {
-    this.focus()
+    exportFiles() {
+      const zip = new JSZip();
+      const folder = zip.folder("octo_exported");
+
+      this.$store.state.documents.all.forEach(({ id, text }) => {
+        folder.file(`${id}.md`, text);        
+      })
+
+      zip.generateAsync({type:"blob"}).then(function(content) {
+          saveAs(content, "octo_exported.zip");
+        });
+    }
   },
 }
 </script>

--- a/pages/docs/export.vue
+++ b/pages/docs/export.vue
@@ -1,6 +1,13 @@
 <template>
-  <div class="container mx-auto p-4 flex">
-    <button class="button button-size-medium button-color-gray" v-on:click="exportFiles">Export documents</button>
+  <div class="container mx-auto p-4 flex flex-col gap-4">
+    <div>
+      <label class="button button-size-medium button-color-gray items-center">
+        <input v-model="withFrontMatter" type="checkbox" class="checkbox" checked>
+        <span class="ml-3">Export with Octo metadata</span>
+      </label>
+    </div>
+    <button class="button button-size-medium button-color-gray" v-on:click="exportFiles(withFrontMatter)">Export
+      documents</button>
   </div>
 </template>
 
@@ -9,23 +16,25 @@ import { saveAs } from 'file-saver';
 import JSZip from 'jszip'
 
 export default {
-  computed: {
-    value() {
-      return JSON.stringify(this.$store.state.documents.all, null, 2)
-    },
+  data() {
+    return {
+      withFrontMatter: true
+    }
   },
   methods: {
-    exportFiles() {
+    exportFiles(withFrontMatter = false) {
       const zip = new JSZip();
       const folder = zip.folder("octo_exported");
 
-      this.$store.state.documents.all.forEach(({ id, text }) => {
-        folder.file(`${id}.md`, text);        
+      this.$store.state.documents.all.forEach((doc) => {
+        const { id, text } = doc
+        const content = withFrontMatter ? `---\nid: ${id}\n---\n${text}` : text
+        folder.file(`${id}.md`, content);
       })
 
-      zip.generateAsync({type:"blob"}).then(function(content) {
-          saveAs(content, "octo_exported.zip");
-        });
+      zip.generateAsync({ type: "blob" }).then(function (content) {
+        saveAs(content, "octo_exported.zip");
+      });
     }
   },
 }

--- a/pages/docs/import.vue
+++ b/pages/docs/import.vue
@@ -2,7 +2,7 @@
   <div class="container mx-auto p-4 flex flex-col flex-grow h-full gap-4">
     <div class="flex flex-col gap-4">
       <label for="markdown-file-uploader">Choose .md file(s) to upload</label>
-      <input ref="uploads" @change="parseFiles" type="file" id="markdown-file-uploader" multiple accept=".md" class="input" />
+      <input ref="uploads" @change="parseFiles" type="file" id="markdown-file-uploader" multiple accept=".md" class="button button-size-medium button-color-gray" />
     </div>
   </div>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,6 +2943,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/file-saver@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@types/file-saver@npm:2.0.5"
+  checksum: a31d6ee2abf99598647139f8f35b37b6e1bacf6c7ddf05c66651b9b0e6e53381aa0e8ed13f37faa6e496e0eb1da87c97e6c70fd589d5b83b0c95c57cb64ce92a
+  languageName: node
+  linkType: hard
+
+"@types/highlight.js@npm:^9.7.0":
+  version: 9.12.4
+  resolution: "@types/highlight.js@npm:9.12.4"
+  checksum: 1a491cc59b58c906b4e1c7263c839b8741f4ef3af395f7e0c90350792d89a832f4c4c39010df577f9c9dd447544c854a45a7c999a7901dc16dc20faedf73e7b5
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.6":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -2977,6 +2991,16 @@ __metadata:
   version: 18.0.6
   resolution: "@types/node@npm:18.0.6"
   checksum: 780f8885a6b6eb12f4c0246617747fdc37a451931b3c01ce8148d356c0903b705dcb16cc6a914de63d48b0dc1b002c7a3dfae681f580e1761aa551d3cd996813
+  languageName: node
+  linkType: hard
+
+"@types/remarkable@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@types/remarkable@npm:2.0.3"
+  dependencies:
+    "@types/highlight.js": ^9.7.0
+    highlight.js: ^9.7.0
+  checksum: 12dfe1f20ad7d930831b98c8f0ff2a0538965276546b5ace6427eefc301c996713bd373f17ffa3a4449546282c7dcdbaa9b8b3806537a876a0f40d3b80109f80
   languageName: node
   linkType: hard
 
@@ -3248,15 +3272,19 @@ __metadata:
   resolution: "@voraciousdev/octo@workspace:."
   dependencies:
     "@tailwindcss/aspect-ratio": ^0.4.0
+    "@types/file-saver": ^2.0.5
     "@types/mime-types": ^2.1.1
     "@types/node": ^18.0.6
+    "@types/remarkable": ^2.0.3
     "@vitejs/plugin-vue": 2
     autoprefixer: ^10.3.6
     deepmerge: ^4.2.2
     deepmerge-ts: ^4.2.1
+    file-saver: ^2.0.5
     firebase: ^9.9.0
     force-graph: ^1.35.1
     ink-mde: ^0.14.1
+    jszip: ^3.10.1
     localforage: ^1.10.0
     mime-types: ^2.1.35
     moment: ^2.29.4
@@ -6212,6 +6240,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-saver@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "file-saver@npm:2.0.5"
+  checksum: c62d96e5cebc58b4bdf3ae8a60d5cf9607ad82f75f798c33a4ee63435ac2203002584d5256a2a780eda7feb5e19dc3b6351c2212e58b3f529e63d265a7cc79f7
+  languageName: node
+  linkType: hard
+
 "file-uri-to-path@npm:1.0.0":
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
@@ -6791,6 +6826,13 @@ __metadata:
   bin:
     he: bin/he
   checksum: 3d4d6babccccd79c5c5a3f929a68af33360d6445587d628087f39a965079d84f18ce9c3d3f917ee1e3978916fc833bb8b29377c3b403f919426f91bc6965e7a7
+  languageName: node
+  linkType: hard
+
+"highlight.js@npm:^9.7.0":
+  version: 9.18.5
+  resolution: "highlight.js@npm:9.18.5"
+  checksum: a8afdb395869bba8a892dd8891b738d3bd48fe2e5b6843ec3181c93d73f52abf2cab863424caa631442a7bbafac222bafdab3f5a536a69aab9c60d4c1b7f8b77
   languageName: node
   linkType: hard
 
@@ -7607,6 +7649,18 @@ __metadata:
   version: 5.0.0
   resolution: "jsonpointer@npm:5.0.0"
   checksum: c7ec0b6bb596b81de687bc12945586bbcdc80dfb54919656d2690d76334f796a936270067ee9f1b5bbc2d9ecc551afb366ac35e6685aa61f07b5b68d1e5e857d
+  languageName: node
+  linkType: hard
+
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: ~3.3.0
+    pako: ~1.0.2
+    readable-stream: ~2.3.6
+    setimmediate: ^1.0.5
+  checksum: abc77bfbe33e691d4d1ac9c74c8851b5761fba6a6986630864f98d876f3fcc2d36817dfc183779f32c00157b5d53a016796677298272a714ae096dfe6b1c8b60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #142 

## Description

Replaces current text input with a frontmatter checkbox toggle & button to export md files.

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/35736525/195902016-df189765-7646-4290-abbb-74c683a1686b.png">

Works when tested with 10 docs in store, adds `id` frontmatter when toggle is on, and without when toggle is off.

## Notes

I'm not sure what other frontmatter is required so I didn't add the others.
UI can probably be better, but I didn't know what's the standard for having a button and an input next to each other (they both look about the same in this app)